### PR TITLE
fix(kcp): declare manifests[] ids, bump kcp_version to 0.29

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -31,7 +31,7 @@ signing:
   signature: "https://raw.githubusercontent.com/Cantara/kcp-commands/main/knowled\
     ge.yaml.sig"
 
-kcp_version: "0.26"
+kcp_version: "0.29"
 project: kcp-commands
 app_version: 0.27.0
 updated: "2026-07-17"
@@ -169,9 +169,13 @@ units:
       ]
 
 manifests:
-  - url: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml
+  # §3.6: `id` is REQUIRED and is how federation.manifest references resolve.
+  # Without it these entries are unreferenceable and the manifest fails validation.
+  - id: kcp-spec
+    url: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml
     relationship: foundation
-  - url: https://wiki.cantara.no/knowledge/projects/kcp.yaml
+  - id: cantara-org
+    url: https://wiki.cantara.no/knowledge/projects/kcp.yaml
     relationship: org-context
 
 relationships:


### PR DESCRIPTION
`kcp validate` failed with **two hard errors** — both `manifests[]` entries omitted `id`, which §3.6 makes REQUIRED. Confirmed against the **v0.26.1** validator too, so the manifest has been invalid at the version it declares.

Not cosmetic: `federation.manifest` references resolve by `id`, so an entry without one cannot be referenced at all.

Also bumps `kcp_version` 0.26 → 0.29.

## The signature gets fixed as a side effect

Touching `knowledge.yaml` triggers the org signing workflow, **fixed in [Cantara/.github#3](https://github.com/Cantara/.github/pull/3)**. Until that fix it wrote a bare base64 blob the toolchain cannot parse — this repo is one of five whose manifests `kcp render` refuses with `tier=failed (unparseable signature file)`. This push replaces it with the RFC-0018 §4.2 envelope, verified by the workflow before commit.

## Three warnings remain — all pre-existing

```
⚠ Unit 'ecosystem-overview': unknown kind 'article'
⚠ Unit 'ecosystem-overview': file not found on disk: 'https://wiki.totto.org/...'
⚠ manifests['cantara-org']: unknown 'relationship' value 'org-context'
```

The third is **latent, not new**: `org-context` has never been in the vocabulary (`child | foundation | governs | peer | archive`), but the validator skips entries with no `id` — so declaring the id is what made it visible. `peer` looks like the intent and I have **not** assumed it; changing a declared relationship is a semantic call for whoever wrote it.

The first two are a related pair: `kind: article` isn't a spec kind, and the unit's `path` is a URL rather than a file, so "not found on disk" follows from the same choice. Both want a decision about how external articles should be modelled — larger than this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)