### PR TITLE
fix(kcp): resolve the signature next to the manifest, not from main

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -28,8 +28,7 @@ signing:
   scheme: ed25519
   scope: this-manifest
   public_key: "MCowBQYDK2VwAyEAuipgusnqU9vjf3p2yPVLD/DmERT6tBbLOqEETdxAhMU="
-  signature: "https://raw.githubusercontent.com/Cantara/kcp-commands/main/knowled\
-    ge.yaml.sig"
+  signature: "knowledge.yaml.sig"
 
 kcp_version: "0.29"
 project: kcp-commands


### PR DESCRIPTION
`signing.signature` points at a hardcoded `main` URL, so a consumer verifying this manifest on **any ref other than `main`** fetches `main`'s signature and checks it against different bytes. That fails by construction on a branch, a release tag, a fork, and any vendored copy — the signature is verifiable at exactly one moving target.

A relative path resolves next to the manifest, which is what a detached signature is for: the two files travel together.

## How this surfaced

It blocked [kcp-agent#121](https://github.com/Cantara/kcp-agent/pull/121) and [kcp-harness#55](https://github.com/Cantara/kcp-harness/pull/55). Those verify their own signature in CI, so a manifest change failed with `signature invalid: ed25519 signature does not match manifest bytes` — and re-signing the branch **did not help and could not**, because the planner fetched `main`'s signature regardless of branch contents. Both fixed and merged.

All six Cantara `kcp-*` manifests had the same URL. This is one of the remaining four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)