### PR TITLE
chore(deps): sqlite-jdbc, js-yaml v5, checkout v7, setup-node v7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Java daemon — build + startup + hook round-trip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
@@ -145,8 +145,8 @@ jobs:
     name: Node.js CLI — build + smoke test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -23,7 +23,7 @@ jobs:
           cache: 'maven'
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'npm'

--- a/commands/index.txt
+++ b/commands/index.txt
@@ -115,10 +115,10 @@ git-tag
 git-worktree
 glab
 go-build
+golangci-lint
 go-mod
 go-run
 go-test
-golangci-lint
 gpg
 gradle
 gradlew

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.53.2.0</version>
+            <version>3.53.2.1</version>
         </dependency>
 
         <!-- Testing -->

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "kcp-commands",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-commands",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^5.2.2"
       },
       "bin": {
         "kcp-commands": "dist/cli.js"
@@ -421,7 +421,8 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
@@ -634,9 +635,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -652,7 +653,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/lightningcss": {
@@ -1136,6 +1137,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,7 +24,7 @@
     "postpack": "rm -rf ./commands"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^5.2.2"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
Consolidates four of the five open Renovate PRs.

| Dependency | From | To | Supersedes |
|---|---|---|---|
| `org.xerial:sqlite-jdbc` | 3.53.2.0 | 3.53.2.1 | #39 |
| `js-yaml` | ^4.1.0 | **^5.2.2** | #38 |
| `actions/checkout` | v6 | v7 | #35 |
| `actions/setup-node` | v4 *and* v6 | v7 | #36 |

The workflows had **two different `setup-node` majors pinned** (v4 in one, v6 in another); both now read v7.

## js-yaml v5 — checked where it matters

This repo parses KCP manifests, and the thing a YAML major is most likely to change is scalar resolution. Given SPEC §2 mandates YAML 1.2, that is the check worth running:

```
a: yes  -> string "yes"
b: no   -> string "no"
c: true -> boolean true
d: off  -> string "off"
e: on   -> string "on"
```

v5 keeps the YAML 1.2 core schema. No regression against §2.

`npm run build` + 18 tests pass; `mvn test` passes.

## Excluded: typescript v7 (#37)

#37 is the one Renovate PR here that fails CI, and it is not a flake. TS7 is the native port and it does not resolve a `@types/node@^24` that is present:

```
src/cli.ts(5,29): error TS2591: Cannot find name 'process'.
src/deviation.ts(1,58): error TS2591: Cannot find name 'node:fs'.
```

It also surfaces a real defect the old compiler missed:

```
src/filter.ts(26,26): error TS2454: Variable 'stdin' is used before being assigned.
```

That second one is worth fixing regardless of TS7. Tracked separately — the same bump is open in two other repos.

Closes #35, #36, #38, #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)