### PR TITLE
chore(release): v0.29.0 — KCP 0.30, signature repair, dependency currency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cantara.kcp</groupId>
     <artifactId>kcp-commands-daemon</artifactId>
-    <version>0.28.0</version>
+    <version>0.29.0</version>
     <packaging>jar</packaging>
 
     <name>kcp-commands-daemon</name>

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kcp-commands",
-  "version": "0.13.0",
-  "description": "Semantic command manifests for the Knowledge Context Protocol — syntax context and noise filtering for CLI commands in AI agent sessions",
+  "version": "0.14.0",
+  "description": "Semantic command manifests for the Knowledge Context Protocol \u2014 syntax context and noise filtering for CLI commands in AI agent sessions",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {


### PR DESCRIPTION
8 commits since v0.28.0. **Minor**: the manifest tracks KCP 0.30.

```
java/pom.xml             0.28.0 -> 0.29.0
typescript/package.json  0.13.0 -> 0.14.0
```

Both move per release, as in v0.28.0 — separate version lines that diverged once (pom jumped 0.12→0.27) and have incremented together since.

| Area | What |
|---|---|
| KCP 0.30 | manifest bumped through 0.29 and 0.30; `manifests[]` ids declared |
| Signatures | the reference resolved from `main` rather than beside the manifest |
| Deps | **js-yaml v5**, sqlite-jdbc 3.53.2.1, checkout v7, setup-node v7 |
| Tools | `update-hashes.py` to refresh RFC-0019 `content_hash` values |

**js-yaml v5 is a major and this repo parses KCP manifests**, so it was checked where a YAML major actually bites — scalar resolution:

```
yes -> string    no -> string    on -> string    off -> string
true -> boolean  false -> boolean
```

v5 keeps the YAML 1.2 core schema, which is what SPEC §2 requires. No regression.

## Not included

**typescript v7 (#37)** — it fails here: TS7 does not resolve a *present* `@types/node@^24`, and surfaces a real `TS2454: 'stdin' is used before being assigned`. The same bump **passes** in knowledge-context-protocol with a near-identical tsconfig, and that difference is still unexplained. Tracked in #44.

```
mvn test passes · TypeScript builds · 18 tests pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)