### PR TITLE
chore(release): v0.29.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cantara.kcp</groupId>
     <artifactId>kcp-commands-daemon</artifactId>
-    <version>0.29.0</version>
+    <version>0.29.1</version>
     <packaging>jar</packaging>
 
     <name>kcp-commands-daemon</name>

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-commands",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-commands",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^5.2.2"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-commands",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Semantic command manifests for the Knowledge Context Protocol \u2014 syntax context and noise filtering for CLI commands in AI agent sessions",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Patch bump: js-yaml 5.2.2 → 5.2.3 (#47). Also the first release to include the typescript v7 fix (#37 / #44), which landed on main before this PR.

java/pom.xml            0.29.0 -> 0.29.1
typescript/package.json 0.14.0 -> 0.14.1

Both version lines move together per release, per this repo's convention.

## Test plan
- [x] `npm run build && npm test` (typescript/) — 18/18 passing
- [x] `mvn test` (java/) — 38/38 passing, BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)